### PR TITLE
Change CI pipeline to avoid duplicate runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,17 @@
 trigger:
-- '*'
+  branches:
+    include:
+    - main
+
+pr:
+  branches:
+    include:
+    - main
+    exclude:
+    - .github/*
+    - '*.md'
+    - '*.txt'
+    - '*.png'
 
 pool:
   name: Default


### PR DESCRIPTION
CI currently triggers on every commit, push and pull-request, which 
means that the pipeline runs multiple times in certain cases. To prevent
this from happening, this changes the CI trigger to run only for commits
to the main branch, pull-requests that are based on the main branch and 
make changes to source files.